### PR TITLE
slides now return there own filename instead of 'uploadcare image'

### DIFF
--- a/djangocms_slider_uploadcare/models.py
+++ b/djangocms_slider_uploadcare/models.py
@@ -41,7 +41,7 @@ class UploadcareSlide(CMSPlugin):
         if self.caption:
             return self.caption[:40]
         else:
-            return "Uploadcare Image"
+            return self.image.info().get('original_filename')
 
     def clean(self):
         if self.url and self.page_link:


### PR DESCRIPTION
Changed the `__str__` on the `UploadcareSlide` model to no longer alway return a default message but instead return the original filename.

This implementation is to increase the usability since finding a specific slide will now be a lot easier.